### PR TITLE
feat: Add KeyValue and EvaluationContext args to compare

### DIFF
--- a/plugins/riot/src/main/java/com/redis/riot/Compare.java
+++ b/plugins/riot/src/main/java/com/redis/riot/Compare.java
@@ -1,7 +1,19 @@
 package com.redis.riot;
 
-import org.springframework.batch.core.Job;
+import com.redis.riot.core.RiotUtils;
+import com.redis.riot.function.StringKeyValue;
+import com.redis.riot.function.ToStringKeyValue;
+import com.redis.spring.batch.item.redis.common.KeyValue;
+import com.redis.spring.batch.item.redis.reader.KeyComparisonItemReader;
 
+import io.lettuce.core.codec.ByteArrayCodec;
+
+import org.springframework.batch.core.Job;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.batch.item.function.FunctionItemProcessor;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import picocli.CommandLine.ArgGroup;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -13,6 +25,12 @@ public class Compare extends AbstractCompareCommand {
 
 	@Option(names = "--quick", description = "Skip value comparison.")
 	private boolean quick;
+
+	@ArgGroup(exclusive = false)
+	private final EvaluationContextArgs evaluationContextArgs = new EvaluationContextArgs();
+
+	@ArgGroup(exclusive = false, heading = "Processor options%n")
+	private final KeyValueProcessorArgs processorArgs = new KeyValueProcessorArgs();
 
 	@Override
 	protected boolean isQuickCompare() {
@@ -27,6 +45,37 @@ public class Compare extends AbstractCompareCommand {
 	@Override
 	protected Job job() {
 		return job(compareStep());
+	}
+
+	private StandardEvaluationContext evaluationContext() {
+		log.info("Creating SpEL evaluation context with {}", evaluationContextArgs);
+		StandardEvaluationContext evaluationContext = evaluationContextArgs.evaluationContext();
+		configure(evaluationContext);
+		return evaluationContext;
+	}
+
+	private ItemProcessor<KeyValue<byte[], Object>, KeyValue<byte[], Object>> keyValueProcessor() {
+		StandardEvaluationContext evaluationContext = evaluationContext();
+		log.info("Creating processor with {}", processorArgs);
+		ItemProcessor<KeyValue<String, Object>, KeyValue<String, Object>> processor = processorArgs
+				.processor(evaluationContext);
+		if (processor == null) {
+			return null;
+		}
+		ToStringKeyValue<byte[]> code = new ToStringKeyValue<>(ByteArrayCodec.INSTANCE);
+		StringKeyValue<byte[]> decode = new StringKeyValue<>(ByteArrayCodec.INSTANCE);
+		return RiotUtils.processor(new FunctionItemProcessor<>(code), processor, new FunctionItemProcessor<>(decode));
+	}
+
+	private ItemProcessor<KeyValue<byte[], Object>, KeyValue<byte[], Object>> processor() {
+		return RiotUtils.processor(new KeyValueFilter<>(ByteArrayCodec.INSTANCE, log), keyValueProcessor());
+	}
+
+	@Override
+	protected KeyComparisonItemReader<byte[], byte[]> compareReader() {
+		KeyComparisonItemReader<byte[], byte[]> reader = super.compareReader();
+		reader.setProcessor(processor());
+		return reader;
 	}
 
 	public boolean isCompareStreamMessageId() {


### PR DESCRIPTION
**Problem Statement:**
The current `compare` command in Redis RIOT does not support specifying key/value processing arguments, such as `--key-proc`, when performing an on-demand comparison. This limits the ability to replicate the same key transformations that are automatically applied during the replication process (e.g., prefixing keys with `--key-proc "yourprefix:#{key}"` argument).

While the automatic comparison after each `replicate` scan cycle correctly respects these transformations, the on-demand `compare` command lacks the capability to apply them, which prevents users from comparing data in the same way as they would during replication.

**Proposed Solution:**
This PR introduces support for key/value processing arguments (e.g., `--key-proc`) to the on-demand compare command using the same `KeyValueProcessorArgs` as in `replicate` command. This ensures that users can apply the same transformations during ad-hoc comparisons as they can during the replication process, maintaining consistent behavior between automatic and on-demand comparisons.

**Benefits:**
- **Feature Parity:** Aligns the on-demand compare command with the automatic compare performed after each scan cycle.
- **Flexibility:** Enables users to run ad-hoc comparisons with the same key/value transformation options used during replication.
- **Improved Workflow:** Helps users verify and debug key manipulations more easily, especially for complex scenarios where keys or values are dynamically transformed during replication.

**Use Case:**
For example, when replicating keys and prefixing them (e.g., with `--key-proc "yourprefix:#{key}"` argument), users cannot currently perform an accurate on-demand comparison because the transformations are not applied in the compare command. This PR resolves that limitation by enabling key/value processing arguments in the on-demand comparison.